### PR TITLE
Add LruSet implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A collection of collection classes for use in Dart.
 
 `listsEqual`, `mapsEqual` and `setsEqual` check collections for equality.
 
-`LruMap` is a map that removes the least recently used item when a threshold
+`LruSet` and `LruMap` are collections that remove the least recently used item when a threshold
 length is exceeded.
 
 `Multimap` is an associative collection that maps keys to collections of

--- a/lib/collection.dart
+++ b/lib/collection.dart
@@ -22,6 +22,7 @@ import 'package:quiver_iterables/iterables.dart';
 
 part 'src/bimap.dart';
 part 'src/lru_map.dart';
+part 'src/lru_set.dart';
 part 'src/multimap.dart';
 part 'src/treeset.dart';
 part 'src/delegates/iterable.dart';

--- a/lib/src/lru_map.dart
+++ b/lib/src/lru_map.dart
@@ -35,30 +35,30 @@ abstract class LruMap<K, V> implements Map<K, V> {
 
 /// Simple implementation of a linked-list entry that contains a [key] and
 /// [value].
-class _LinkedEntry<K, V> {
+class _LinkedMapEntry<K, V> {
   K key;
   V value;
 
-  _LinkedEntry<K, V> next;
-  _LinkedEntry<K, V> previous;
+  _LinkedMapEntry<K, V> next;
+  _LinkedMapEntry<K, V> previous;
 
-  _LinkedEntry([this.key, this.value]);
+  _LinkedMapEntry([this.key, this.value]);
 }
 
 /// A linked hash-table based implementation of [LruMap].
 class LinkedLruHashMap<K, V> implements LruMap<K, V> {
   static const _DEFAULT_MAXIMUM_SIZE = 100;
 
-  final Map<K, _LinkedEntry<K, V>> _entries;
+  final Map<K, _LinkedMapEntry<K, V>> _entries;
 
   int _maximumSize;
 
-  _LinkedEntry<K, V> _head;
-  _LinkedEntry<K, V> _tail;
+  _LinkedMapEntry<K, V> _head;
+  _LinkedMapEntry<K, V> _tail;
 
   /// Create a new LinkedLruHashMap with a [maximumSize].
   factory LinkedLruHashMap({int maximumSize}) =>
-      new LinkedLruHashMap._fromMap(new HashMap<K, _LinkedEntry<K, V>>(),
+      new LinkedLruHashMap._fromMap(new HashMap<K, _LinkedMapEntry<K, V>>(),
           maximumSize: maximumSize);
 
   LinkedLruHashMap._fromMap(this._entries, {int maximumSize})
@@ -114,8 +114,8 @@ class LinkedLruHashMap<K, V> implements LruMap<K, V> {
   bool get isNotEmpty => _entries.isNotEmpty;
 
   /// Creates an [Iterable] around the entries of the map.
-  Iterable<_LinkedEntry<K, V>> _iterable() {
-    return new GeneratingIterable<_LinkedEntry<K, V>>(
+  Iterable<_LinkedMapEntry<K, V>> _iterable() {
+    return new GeneratingIterable<_LinkedMapEntry<K, V>>(
         () => _head, (n) => n.next);
   }
 
@@ -214,7 +214,7 @@ class LinkedLruHashMap<K, V> implements LruMap<K, V> {
   String toString() => Maps.mapToString(this);
 
   /// Moves [entry] to the MRU position, shifting the linked list if necessary.
-  void _promoteEntry(_LinkedEntry<K, V> entry) {
+  void _promoteEntry(_LinkedMapEntry<K, V> entry) {
     if (entry.previous != null) {
       // If already existed in the map, link previous to next.
       entry.previous.next = entry.next;
@@ -241,14 +241,14 @@ class LinkedLruHashMap<K, V> implements LruMap<K, V> {
   }
 
   /// Creates and returns an entry from [key] and [value].
-  _LinkedEntry<K, V> _createEntry(K key, V value) {
-    return new _LinkedEntry<K, V>(key, value);
+  _LinkedMapEntry<K, V> _createEntry(K key, V value) {
+    return new _LinkedMapEntry<K, V>(key, value);
   }
 
   /// If [entry] does not exist, inserts it into the backing map. If it does,
   /// replaces the existing [_LinkedEntry.value] with [entry.value]. Then, in
   /// either case, promotes [entry] to the MRU position.
-  void _insertMru(_LinkedEntry<K, V> entry) {
+  void _insertMru(_LinkedMapEntry<K, V> entry) {
     // Insert a new entry if necessary (only 1 hash lookup in entire function).
     // Otherwise, just updates the existing value.
     final value = entry.value;

--- a/lib/src/lru_set.dart
+++ b/lib/src/lru_set.dart
@@ -1,0 +1,285 @@
+// Copyright 2014 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+part of quiver.collection;
+
+/**
+ * An implementation of a [Set] which has a maximum size and uses a (Least
+ * Recently Used)[http://en.wikipedia.org/wiki/Cache_algorithms#LRU] algorithm
+ * to remove items from the [Set] when the [maximumSize] is reached and new
+ * items are added.
+ *
+ * It is safe to access the iterator and contains method without affecting
+ * the "used" ordering - as well as using [forEach]. Other types of access,
+ * including lookup, promotes the key-value pair to the MRU position.
+ */
+abstract class LruSet<E> implements Set<E> {
+  /**
+   * Creates a [LruMap] instance with the default implementation.
+   */
+  factory LruSet({int maximumSize}) = LinkedLruHashSet;
+
+  /**
+   * Maximum size of the [Map]. If [length] exceeds this value at any time,
+   * n entries accessed the earliest are removed, where n is [length] -
+   * [maximumSize].
+   */
+  int maximumSize;
+}
+
+/**
+ * Simple implementation of a linked-list entry that contains a [key] and
+ * [element].
+ */
+class _LinkedSetEntry<E> {
+  E element;
+
+  _LinkedSetEntry<E> next;
+  _LinkedSetEntry<E> previous;
+
+  _LinkedSetEntry([this.element]);
+}
+
+/**
+ * A linked hash-table based implementation of [LruSet].
+ */
+class LinkedLruHashSet<E> extends SetBase<E> implements LruSet<E> {
+  static const _DEFAULT_MAXIMUM_SIZE = 100;
+
+  final HashMap<E, _LinkedSetEntry<E>> _entries;
+
+  int _maximumSize;
+
+  _LinkedSetEntry<E> _head;
+  _LinkedSetEntry<E> _tail;
+
+  /**
+   * Create a new LinkedLruHashMap with a [maximumSize].
+   */
+  factory LinkedLruHashSet({int maximumSize}) =>
+      new LinkedLruHashSet._fromSet(new HashMap<E, _LinkedSetEntry<E>>(),
+          maximumSize: maximumSize);
+
+  LinkedLruHashSet._fromSet(this._entries, {int maximumSize})
+      // This pattern is used instead of a default value because we want to
+      // be able to respect null values coming in from MapCache.lru.
+      : _maximumSize = firstNonNull(maximumSize, _DEFAULT_MAXIMUM_SIZE);
+
+  /**
+   * If [element] already exists, promotes it to the MRU position.
+   *
+   * Otherwise, adds [element] to the MRU position.
+   * If [length] exceeds [maximumSize] while adding, removes the LRU position.
+   */
+  @override
+  bool add(E element) {
+    bool wasPresent = _entries.containsKey(element);
+    _insertMru(_createEntry(element));
+
+    // Remove the LRU item if the size would be exceeded by adding this item.
+    if (length > maximumSize) {
+      assert(length == maximumSize + 1);
+      _removeLru();
+    }
+    return !wasPresent;
+  }
+
+  /**
+   * Adds all key-value pairs of [other] to this set.
+   *
+   * The operation is equivalent to doing this[key] = value for each key and
+   * associated value in other. It iterates over other, which must therefore not
+   * change during the iteration.
+   *
+   * If the number of unique keys is greater than [maximumSize] then the least
+   * recently use keys are evicted. For items added by [other], the least
+   * recently user order is determined by [other]'s iteration order.
+   */
+  @override
+  void addAll(Set<E> other) => other.forEach((v) => this.add(v));
+
+  @override
+  void clear() {
+    _entries.clear();
+    _head = _tail = null;
+  }
+
+  /**
+   * If an object equal to object is in the set, return it.
+   *
+   * Checks if there is an object in the set that is equal to object.
+   * If so, that object is returned, otherwise returns null.
+   *
+   * The [element] will be promoted to the 'Most Recently Used' position.
+   */
+  @override lookup(E element) {
+    final entry = _entries[element];
+    if (entry != null) {
+      _promoteEntry(entry);
+      return entry.element;
+    } else {
+      return null;
+    }
+  }
+
+  @override
+  bool contains(E element) => _entries.containsKey(element);
+
+  @override
+  E get first {
+    if (isEmpty) throw new StateError("Set is empty");
+    return _head.element;
+  }
+
+  /**
+   * Returns the last element.
+   *
+   * This operation is performed in constant time.
+   */
+  @override
+  E get last {
+    if (isEmpty) throw new StateError("Set is empty");
+    return _tail.element;
+  }
+
+  /**
+   * Applies [action] to each key-value pair of the map in order of MRU to LRU.
+   *
+   * Calling `action` must not add or remove keys from the map.
+   */
+  @override
+  void forEach(void action(E element)) {
+    var head = _head;
+    while (head != null) {
+      action(head.element);
+      head = head.next;
+    }
+  }
+
+  @override
+  int get length => _entries.length;
+
+  @override
+  bool get isEmpty => _entries.isEmpty;
+
+  @override
+  bool get isNotEmpty => _entries.isNotEmpty;
+
+  @override
+  Iterator<E> get iterator => _iterable().map((e) => e.element).iterator;
+
+  /**
+   * Creates an [Iterable] around the entries of the map.
+   */
+  Iterable<_LinkedSetEntry<E>> _iterable() {
+    return new GeneratingIterable<_LinkedSetEntry<E>>(
+        () => _head, (n) => n.next);
+  }
+
+  @override
+  int get maximumSize => _maximumSize;
+
+  @override
+  void set maximumSize(int maximumSize) {
+    if (maximumSize == null) throw new ArgumentError.notNull('maximumSize');
+    while (length > maximumSize) {
+      _removeLru();
+    }
+    _maximumSize = maximumSize;
+  }
+
+  @override
+  bool remove(E element) {
+    final _LinkedSetEntry entry = _entries.remove(element);
+    if (entry != null) {
+      if (entry == _head) {
+        _head = _head.next;
+      } else if (entry == _tail) {
+        _tail.previous.next = null;
+        _tail = _tail.previous;
+      } else {
+        entry.previous.next = entry.next;
+      }
+      return true;
+    }
+    return false;
+  }
+
+  @override
+  Set<E> toSet() => _entries.keys.toSet();
+
+  @override
+  String toString() => _entries.keys.toString();
+
+  /**
+   * Moves [entry] to the MRU position, shifting the linked list if necessary.
+   */
+  void _promoteEntry(_LinkedSetEntry<E> entry) {
+    if (entry.previous != null) {
+      // If already existed in the map, link previous to next.
+      entry.previous.next = entry.next;
+
+      // If this was the tail element, assign a new tail.
+      if (_tail == entry) {
+        _tail = entry.previous;
+      }
+    }
+
+    // Replace head with this element.
+    if (_head != null) {
+      _head.previous = entry;
+    }
+    entry.previous = null;
+    entry.next = _head;
+    _head = entry;
+
+    // Add a tail if this is the first element.
+    if (_tail == null) {
+      assert(length == 1);
+      _tail = _head;
+    }
+  }
+
+  /**
+   * Creates and returns an entry from [key] and [value].
+   */
+  _LinkedSetEntry<E> _createEntry(E value) {
+    return new _LinkedSetEntry<E>(value);
+  }
+
+  /**
+   * If [entry] does not exist, inserts it into the backing map.
+   * If it does, replaces the existing [_LinkedEntry.value] with [entry.value].
+   * Then, in either case, promotes [entry] to the MRU position.
+   */
+  void _insertMru(_LinkedSetEntry<E> entry) {
+    // Insert a new entry if necessary (only 1 hash lookup in entire function).
+    // Otherwise, just updates the existing value.
+    final value = entry.element;
+    _promoteEntry(
+        _entries.putIfAbsent(entry.element, () => entry)..element = value);
+  }
+
+  /**
+   * Removes the LRU position, shifting the linked list if necessary.
+   */
+  void _removeLru() {
+    // Remove the tail from the internal map.
+    _entries.remove(_tail.element);
+
+    // Remove the tail element itself.
+    _tail = _tail.previous;
+    _tail.next = null;
+  }
+}

--- a/lib/src/lru_set.dart
+++ b/lib/src/lru_set.dart
@@ -74,7 +74,7 @@ class LinkedLruHashSet<E> extends SetBase<E> implements LruSet<E> {
   LinkedLruHashSet._fromSet(this._entries, {int maximumSize})
       // This pattern is used instead of a default value because we want to
       // be able to respect null values coming in from MapCache.lru.
-      : _maximumSize = firstNonNull(maximumSize, _DEFAULT_MAXIMUM_SIZE);
+      : _maximumSize = maximumSize ?? _DEFAULT_MAXIMUM_SIZE;
 
   /**
    * If [element] already exists, promotes it to the MRU position.

--- a/test/lru_set_test.dart
+++ b/test/lru_set_test.dart
@@ -1,0 +1,183 @@
+// Copyright 2014 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+library quiver.collection.lru_map_test;
+
+import 'package:quiver_collection/collection.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('LruSet', () {
+    /// A set that will be initialize by individual tests.
+    LruSet<String> lruSet;
+
+    test('the length property reflects how many elements are in the set', () {
+      lruSet = new LruSet();
+      expect(lruSet, hasLength(0));
+
+      lruSet.addAll(new Set.from(['A', 'B', 'C']));
+      expect(lruSet, hasLength(3));
+    });
+
+    test('accessing elements causes them to be promoted', () {
+      lruSet = new LruSet()..addAll(new Set.from(['A', 'B', 'C']));
+
+      expect(lruSet.toList(), ['C', 'B', 'A']);
+
+      lruSet.lookup('B');
+
+      // In a LRU cache, the first element is the one that will be removed if the
+      // capacity is reached, so adding elements to the end is considered to be a
+      // 'promotion'.
+      expect(lruSet.toList(), ['B', 'C', 'A']);
+    });
+
+    test('new elements are added at the beginning', () {
+      lruSet = new LruSet()..addAll(new Set.from(['A', 'B', 'C']));
+
+      lruSet.add('D');
+      expect(lruSet.toList(), ['D', 'C', 'B', 'A']);
+    });
+
+    test('setting values on existing elements works, and promotes the key', () {
+      lruSet = new LruSet()..addAll(new Set.from(['A', 'B', 'C']));
+
+      lruSet.add('B');
+      expect(lruSet.toList(), ['B', 'C', 'A']);
+    });
+
+    test('the least recently used element is evicted when capacity hit', () {
+      lruSet = new LruSet(maximumSize: 3)
+        ..addAll(new Set.from(['A', 'B', 'C']));
+
+      lruSet.add('D');
+      expect(lruSet.toList(), ['D', 'C', 'B']);
+    });
+
+    test('setting maximum size evicts elements until the size is met', () {
+      lruSet = new LruSet(maximumSize: 5)
+        ..addAll(new Set.from(['A', 'B', 'C', 'D', 'E']));
+
+      lruSet.maximumSize = 3;
+      expect(lruSet.toList(), ['E', 'D', 'C']);
+    });
+
+    test('accessing the iterator does not affect position', () {
+      lruSet = new LruSet()..addAll(new Set.from(['A', 'B', 'C']));
+
+      expect(lruSet.toList(), ['C', 'B', 'A']);
+
+      Iterator iterator = lruSet.iterator;
+      while (iterator.moveNext());
+
+      expect(lruSet.toList(), ['C', 'B', 'A']);
+    });
+
+    test('clearing removes all elements', () {
+      lruSet = new LruSet()..addAll(new Set.from(['A', 'B', 'C']));
+
+      expect(lruSet.isNotEmpty, isTrue);
+
+      lruSet.clear();
+
+      expect(lruSet.isEmpty, isTrue);
+    });
+
+    test('`contains` returns true if the element is in the set', () {
+      lruSet = new LruSet()..addAll(new Set.from(['A', 'B', 'C']));
+
+      expect(lruSet.contains('A'), isTrue);
+      expect(lruSet.contains('D'), isFalse);
+    });
+
+    test('`first` returns first element', () {
+      lruSet = new LruSet()..addAll(new Set.from(['A', 'B', 'C']));
+
+      expect(lruSet.first, 'C');
+    });
+
+    test('`last` returns last element and does not change order', () {
+      lruSet = new LruSet()..addAll(new Set.from(['A', 'B', 'C']));
+
+      expect(lruSet.last, 'A');
+      expect(lruSet.toList(), ['C', 'B', 'A']);
+    });
+
+    test('`forEach` returns all items without modifying order', () {
+      final elements = [];
+
+      lruSet = new LruSet()..addAll(new Set.from(['A', 'B', 'C']));
+
+      expect(lruSet.toList(), ['C', 'B', 'A']);
+
+      lruSet.forEach((element) {
+        elements.add(element);
+      });
+
+      expect(elements, ['C', 'B', 'A']);
+      expect(lruSet.toList(), ['C', 'B', 'A']);
+    });
+
+    group('`remove`', () {
+      setUp(() {
+        lruSet = new LruSet()..addAll(new Set.from(['A', 'B', 'C']));
+      });
+
+      test('returns the value associated with a key, if it exists', () {
+        expect(lruSet.remove('A'), true);
+      });
+
+      test('returns null if the provided element does not exist', () {
+        expect(lruSet.remove('D'), false);
+      });
+
+      test('can remove the head', () {
+        lruSet.remove('C');
+        expect(lruSet.toList(), ['B', 'A']);
+      });
+
+      test('can remove the tail', () {
+        lruSet.remove('A');
+        expect(lruSet.toList(), ['C', 'B']);
+      });
+
+      test('can remove a middle entry', () {
+        lruSet.remove('B');
+        expect(lruSet.toList(), ['C', 'A']);
+      });
+    });
+
+    group('`add`', () {
+      setUp(() {
+        lruSet = new LruSet()..addAll(new Set.from(['A', 'B', 'C']));
+      });
+
+      test('adds an item if it does not exist, and moves it to the MRU', () {
+        expect(lruSet.add('D'), true);
+        expect(lruSet.toList(), ['D', 'C', 'B', 'A']);
+      });
+
+      test('does not add an item if it exists, but does promote it to MRU', () {
+        expect(lruSet.add('B'), false);
+        expect(lruSet.toList(), ['B', 'C', 'A']);
+      });
+
+      test('removes the LRU item if `maximumSize` exceeded', () {
+        lruSet.maximumSize = 3;
+        expect(lruSet.add('D'), true);
+        expect(lruSet.toList(), ['D', 'C', 'B']);
+      });
+    });
+  });
+}

--- a/test/lru_set_test.dart
+++ b/test/lru_set_test.dart
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library quiver.collection.lru_map_test;
+library quiver.collection.lru_set_test;
 
 import 'package:quiver_collection/collection.dart';
 import 'package:test/test.dart';


### PR DESCRIPTION
Implements LruSet in a similar fashion to LruMap.

Fixes google/quiver-dart#279 and replaces google/quiver-dart/pull/280
